### PR TITLE
Initialize Swift project skeleton

### DIFF
--- a/FitTrack/App/DI/Container.swift
+++ b/FitTrack/App/DI/Container.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+final class Container {
+    static let shared = Container()
+    private init() {}
+}

--- a/FitTrack/App/FitTrackApp.swift
+++ b/FitTrack/App/FitTrackApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct FitTrackApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, FitTrack")
+        }
+    }
+}

--- a/FitTrack/Data/Database/Migrations.sql
+++ b/FitTrack/Data/Database/Migrations.sql
@@ -1,0 +1,48 @@
+CREATE TABLE exercise (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  aliases TEXT,
+  muscles_primary TEXT NOT NULL,
+  muscles_secondary TEXT,
+  region TEXT,
+  equipment TEXT,
+  type TEXT,
+  stability TEXT,
+  image_name TEXT,
+  notes TEXT,
+  is_custom INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE workout (
+  id TEXT PRIMARY KEY,
+  started_at REAL NOT NULL,
+  ended_at REAL,
+  status TEXT NOT NULL,
+  notes TEXT
+);
+
+CREATE TABLE workout_item (
+  id TEXT PRIMARY KEY,
+  workout_id TEXT NOT NULL REFERENCES workout(id) ON DELETE CASCADE,
+  exercise_id TEXT NOT NULL REFERENCES exercise(id),
+  ord INTEGER NOT NULL,
+  targets TEXT NOT NULL,
+  warmup_scheme TEXT,
+  superset_key TEXT
+);
+
+CREATE TABLE set_entry (
+  id TEXT PRIMARY KEY,
+  workout_item_id TEXT NOT NULL REFERENCES workout_item(id) ON DELETE CASCADE,
+  idx INTEGER NOT NULL,
+  reps INTEGER NOT NULL CHECK (reps >= 0 AND reps <= 50),
+  load REAL NOT NULL CHECK (load >= 0),
+  rpe REAL,
+  is_warmup INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
+  duration_sec INTEGER
+);
+
+CREATE INDEX idx_set_entry_item_idx ON set_entry(workout_item_id, idx);
+CREATE INDEX idx_workout_started ON workout(started_at);
+CREATE INDEX idx_exercise_name ON exercise(name);

--- a/FitTrack/Data/Seed/exercises_seed.json
+++ b/FitTrack/Data/Seed/exercises_seed.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "name": "Bench Press (barre)",
+    "aliases": ["Développé couché"],
+    "musclesPrimary": ["Pectoraux"],
+    "musclesSecondary": ["Triceps", "Épaules antérieures"],
+    "region": "Haut du corps",
+    "equipment": ["Barbell", "Bench"],
+    "type": "strength",
+    "stability": "free",
+    "imageName": "bench_bar.png",
+    "notes": "Scapula serrée, pieds ancrés.",
+    "isCustom": false
+  },
+  {
+    "id": "00000000-0000-0000-0000-000000000002",
+    "name": "Squat (barre)",
+    "aliases": ["Back Squat"],
+    "musclesPrimary": ["Quadriceps"],
+    "musclesSecondary": ["Fessiers", "Ischios"],
+    "region": "Bas du corps",
+    "equipment": ["Barbell", "Rack"],
+    "type": "strength",
+    "stability": "free",
+    "imageName": "squat_bar.png",
+    "notes": "Profondeur à la parallèle, dos neutre.",
+    "isCustom": false
+  }
+]

--- a/FitTrack/Domain/Models/BodyMeasure.swift
+++ b/FitTrack/Domain/Models/BodyMeasure.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct BodyMeasure: Identifiable, Codable, Equatable {
+    let id: UUID
+    var date: Date
+    var weight: Double?
+    var bodyFat: Double?
+    var waist: Double?
+}

--- a/FitTrack/Domain/Models/Exercise.swift
+++ b/FitTrack/Domain/Models/Exercise.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum Muscle: String, Codable, CaseIterable {
+    case pectoraux = "Pectoraux"
+    case dos = "Dos"
+    case quadriceps = "Quadriceps"
+    case ischios = "Ischios"
+    case fessiers = "Fessiers"
+    case epaulesAnterieures = "Épaules antérieures"
+    case epaulesLaterales = "Épaules latérales"
+    case epaulesPosteriores = "Épaules postérieures"
+    case biceps = "Biceps"
+    case triceps = "Triceps"
+    case mollets = "Mollets"
+    case core = "Core"
+}
+
+enum BodyRegion: String, Codable, CaseIterable {
+    case upper = "Haut du corps"
+    case lower = "Bas du corps"
+}
+
+enum Equipment: String, Codable, CaseIterable {
+    case barbell = "Barbell"
+    case bench = "Bench"
+    case rack = "Rack"
+    case dumbbell = "Dumbbell"
+    case machine = "Machine"
+    case bodyweight = "Bodyweight"
+    case kettlebell = "Kettlebell"
+    case band = "Band"
+}
+
+enum ExerciseType: String, Codable {
+    case strength
+    case cardio
+    case stretch
+}
+
+enum Stability: String, Codable {
+    case free
+    case machine
+}
+
+struct Exercise: Identifiable, Codable, Equatable {
+    let id: UUID
+    var name: String
+    var aliases: [String]
+    var musclesPrimary: [Muscle]
+    var musclesSecondary: [Muscle]
+    var region: BodyRegion
+    var equipment: [Equipment]
+    var type: ExerciseType
+    var stability: Stability
+    var imageName: String?
+    var notes: String?
+    var isCustom: Bool
+}

--- a/FitTrack/Domain/Models/PR.swift
+++ b/FitTrack/Domain/Models/PR.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum PRMetric: String, Codable {
+    case bestE1RM = "best_e1rm"
+    case best10RM = "best_10RM"
+    case bestLoadAtReps = "best_load_at_reps"
+}
+
+struct PR: Identifiable, Codable, Equatable {
+    let id: UUID
+    let exerciseId: UUID
+    var metric: PRMetric
+    var value: Double
+    var date: Date
+}

--- a/FitTrack/Domain/Models/SetEntry.swift
+++ b/FitTrack/Domain/Models/SetEntry.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct SetEntry: Identifiable, Codable, Equatable {
+    let id: UUID
+    let workoutItemId: UUID
+    var index: Int
+    var reps: Int
+    var load: Double
+    var rpe: Double?
+    var isWarmup: Bool
+    var notes: String?
+    var durationSec: Int?
+}

--- a/FitTrack/Domain/Models/Workout.swift
+++ b/FitTrack/Domain/Models/Workout.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum WorkoutStatus: String, Codable {
+    case inProgress = "in_progress"
+    case completed
+    case archived
+}
+
+struct Workout: Identifiable, Codable, Equatable {
+    let id: UUID
+    var startedAt: Date
+    var endedAt: Date?
+    var status: WorkoutStatus
+    var notes: String?
+}

--- a/FitTrack/Domain/Models/WorkoutItem.swift
+++ b/FitTrack/Domain/Models/WorkoutItem.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct Targets: Codable, Equatable {
+    var sets: Int
+    var repsRange: [Int]
+    var rpe: Double?
+    var restSeconds: Int
+}
+
+struct WarmupStep: Codable, Equatable {
+    var loadPercentage: Double
+    var reps: Int
+}
+
+struct WarmupScheme: Codable, Equatable {
+    var steps: [WarmupStep]
+}
+
+struct WorkoutItem: Identifiable, Codable, Equatable {
+    let id: UUID
+    let workoutId: UUID
+    var exerciseId: UUID
+    var order: Int
+    var targets: Targets
+    var warmupScheme: WarmupScheme?
+    var supersetKey: String?
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# PumpLog
+# FitTrack
+
+Ébauche du projet iOS hors‑ligne pour la planification et le suivi de séances de musculation.
+
+## Structure
+- `FitTrack/App` : point d'entrée SwiftUI et conteneur d'injection de dépendances.
+- `FitTrack/Domain/Models` : modèles métier (Exercise, Workout, SetEntry, etc.).
+- `FitTrack/Data/Database` : schéma SQLite (migrations GRDB).
+- `FitTrack/Data/Seed` : exemple de données d'initialisation.
+
+Cette base sert de point de départ pour implémenter les fonctionnalités décrites dans le brief.


### PR DESCRIPTION
## Summary
- scaffold FitTrack iOS app structure
- add core domain models and database schema
- provide initial exercise seed data

## Testing
- `swiftc -typecheck FitTrack/Domain/Models/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_689d8a3d0340832dba0d9295f7b877b4